### PR TITLE
Update SeeClickFix endpoints

### DIFF
--- a/lib/endpoints.json
+++ b/lib/endpoints.json
@@ -59,7 +59,7 @@
         "endpoint": "http://seeclickfix.com/manor/open311/"
     },
     "new haven": {
-        "endpoint": "http://seeclickfix.com/new-haven/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/29/"
     },
     "newark": {
         "endpoint": "http://seeclickfix.com/newark_2/open311/"


### PR DESCRIPTION
The URLs seem to have changed and I can't find a directory of "account id" (as they seem to be defined in the docs): https://seeclickfix.com/open311/v2/docs