### PR TITLE
Update Open311 endpoints with new SCF links

### DIFF
--- a/lib/endpoints.json
+++ b/lib/endpoints.json
@@ -1,6 +1,6 @@
 {
     "bainbridge": {
-        "endpoint": "http://seeclickfix.com/bainbridge-island/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/38/"
     },
     "baltimore": {
         "endpoint": "http://311.baltimorecity.gov/open311/v2/"
@@ -18,10 +18,10 @@
         "endpoint" : "http://311api.cityofchicago.org/open311/v2/"
     },
     "corona": {
-        "endpoint": "http://seeclickfix.com/corona/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/70/"
     },
     "darwin": {
-        "endpoint": "http://seeclickfix.com/aus_darwin/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/111/"
     },
     "dc": {
         "endpoint": "http://app.311.dc.gov/CWI/Open311/v2/",
@@ -32,10 +32,10 @@
         "endpoint": "http://seeclickfix.com/de-leon/open311/"
     },
     "dunwoody": {
-        "endpoint": "http://seeclickfix.com/dunwoody_ga/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/112/"
     },
     "fontana": {
-        "endpoint": "http://seeclickfix.com/fontana/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/159/"
     },
     "grand rapids": {
         "endpoint": "http://grcity.spotreporters.com/open311/v2/"
@@ -44,43 +44,43 @@
         "endpoint": "https://asiointi.hel.fi/palautews/rest/v1/"
     },
     "hillsborough": {
-        "endpoint": "http://seeclickfix.com/hillsborough/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/45/"
     },
     "howard county": {
-        "endpoint": "http://seeclickfix.com/md_howard-county/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/520/"
     },
     "huntsville": {
-        "endpoint": "http://seeclickfix.com/huntsville/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/145/"
     },
     "macon": {
         "endpoint": "http://seeclickfix.com/macon/open311/"
     },
     "manor": {
-        "endpoint": "http://seeclickfix.com/manor/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/33/"
     },
     "new haven": {
-        "endpoint": "http://seeclickfix.com/new-haven/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/29/"
     },
     "newark": {
-        "endpoint": "http://seeclickfix.com/newark_2/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/809/"
     },
     "newberg": {
-        "endpoint": "http://seeclickfix.com/newberg/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/122/"
     },
     "newnan": {
-        "endpoint": "http://seeclickfix.com/newnan/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/161/"
     },
     "olathe": {
-        "endpoint": "http://seeclickfix.com/olathe/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/106/"
     },
     "raleigh": {
-        "endpoint": "http://seeclickfix.com/raleigh/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/149/"
     },
     "richmond": {
-        "endpoint": "http://seeclickfix.com/richmond/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/102/"
     },
     "roosevelt island": {
-        "endpoint": "http://seeclickfix.com/roosevelt-island/open311/"
+        "endpoint": "https://seeclickfix.com/open311/v2/115/"
     },
     "rostock": {
         "endpoint": "https://geo.sv.rostock.de/citysdk/"

--- a/lib/endpoints.json
+++ b/lib/endpoints.json
@@ -28,9 +28,6 @@
         "format": "xml",
         "jurisdiction": "dc.gov"
     },
-    "deleon": {
-        "endpoint": "http://seeclickfix.com/de-leon/open311/"
-    },
     "dunwoody": {
         "endpoint": "https://seeclickfix.com/open311/v2/112/"
     },
@@ -51,9 +48,6 @@
     },
     "huntsville": {
         "endpoint": "https://seeclickfix.com/open311/v2/145/"
-    },
-    "macon": {
-        "endpoint": "http://seeclickfix.com/macon/open311/"
     },
     "manor": {
         "endpoint": "https://seeclickfix.com/open311/v2/33/"
@@ -85,17 +79,11 @@
     "rostock": {
         "endpoint": "https://geo.sv.rostock.de/citysdk/"
     },
-    "russell springs": {
-        "endpoint": "http://seeclickfix.com/russell-springs/open311/"
-    },
     "san francisco": {
         "endpoint": "http://mobile311.sfgov.org/open311/v2/"
     },
     "toronto": {
         "endpoint": "https://secure.toronto.ca/webwizard/ws/",
         "jurisdiction": "toronto.ca"
-    },
-    "tucson": {
-        "endpoint": "http://seeclickfix.com/tucson/open311/"
     }
 }


### PR DESCRIPTION
The URLs for the SeeClickFix Open311 endpoints that were listed in `endpoints.json` were linking to our old endpoints and broken. I'm an employee of SCF and have updated the list to point to each location's new SCF open311 endpoint, and deleted the ones that don't have an account ID to query by. 