### PR TITLE
Add Contributors and Contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contribution Guidelines
+
+## Steps
+
+1. Fork [the repo](https://github.com/codeforamerica/open311status)
+2. Install it [according to the instructions](README.md#development)
+4. Make your changes
+5. Test your changes
+5. Create a Pull Request
+6. Celebrate!! 🎉
+
+## Notes
+
+When contributing, please make sure to update the [CONTRIBUTORS file](CONTRIBUTORS.md)
+when you submit your pull request. Upon merging of your first pull request,
+you will be given commit access to the repository.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,13 @@
+## Maintainers
+
+- [Ben Sheldon](https://github.com/bensheldon)
+- [Philip Ashlock](https://github.com/philipashlock)
+
+## Contributors
+
+- [Forest Gregg](https://github.com/fgregg)
+- [Matthias Meißer](https://github.com/kvlahromei)
+- [Mick Thompson](https://github.com/mick)
+- [Michelle Lee](https://github.com/mishmosh)
+- [Mark Headd](https://github.com/mheadd)
+- [zdicesare](https://github.com/zdicesare)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Open311 Status monitors and aggregates the status of dozens of Open311 API endpo
 - **Comprehensiveness**: how fully the API is implemented/adopted; e.g. the number of service types that can be submitted through the API
 - **Utilization**: how much the 311 service being used; e.g. the number of service requests submitted
 
-## Development setup
+## Development
 
 ### Requirements
 1. Install Ruby with your ruby version manager of choice, like [rbenv](https://github.com/rbenv/rbenv) or [RVM](https://github.com/codeforamerica/howto/blob/master/Ruby.md)


### PR DESCRIPTION
Contribution Guidelines adopts the [Pull Request Hack](http://felixge.de/2013/03/11/the-pull-request-hack.html) process of giving contributors commit access. 