### PR TITLE
Fix generation of sitemap routes

### DIFF
--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -24,6 +24,10 @@ class ServiceRequest < ActiveRecord::Base
 
   belongs_to :city
 
+  def parameterize
+    { city_slug: city.slug, service_request_id: service_request_id, slug: slug }
+  end
+
   def raw_data=(json)
     super.tap do
       self[:service_request_id] = json['service_request_id']

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -11,7 +11,7 @@
             | Open311.org
         li
           | Help us <strong>improve the code</strong> at
-          =< link_to 'https://github.com/codeforamerica/open311status', rel: "noopener" do
+          =< link_to github_url, rel: "noopener" do
             => fa_icon 'github-alt'
             | Github
         li

--- a/app/views/layouts/_navigation.html.slim
+++ b/app/views/layouts/_navigation.html.slim
@@ -9,7 +9,7 @@ nav.navbar.navbar-default
       = link_to 'Open311 Status', root_path, class: 'navbar-brand'
     .collapse.navbar-collapse
       ul.nav.navbar-nav.navbar-right
-        li= link_to 'https://github.com/codeforamerica/open311status', target: '_blank', rel: 'noopener' do
+        li= link_to github_url, target: '_blank', rel: 'noopener' do
           => fa_icon 'github-alt'
           | Github
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,21 @@ Rails.application.routes.draw do
   get '/sitemap.xml.gz', to: redirect("https://#{Rails.application.secrets.s3_bucket_name}.s3.amazonaws.com/sitemaps/sitemap.xml.gz")
 
   resolve "ServiceRequest" do |service_request, options|
+    service_request.parameterize.merge(controller: 'cities/requests', action: 'show').merge(options)
+  end
+
+  direct :github do
+    'https://github.com/codeforamerica/open311status'
+  end
+end
+
+Rails.application.routes.named_routes.url_helpers_module.module_eval do
+  def service_request_path(service_request, options = {})
+    slug_city_request_path(service_request.city.slug, service_request.service_request_id, service_request.slug, options)
+  end
+
+  def service_request_url(service_request, options = {})
     slug_city_request_url(service_request.city.slug, service_request.service_request_id, service_request.slug, options)
   end
 end
+

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -20,10 +20,10 @@ end
 
 SitemapGenerator::Sitemap.create do
   City.find_each do |city|
-    add city_path(city), changefreq: 'daily'
+    add city_url(city, default_url_options), changefreq: 'daily'
   end
 
   ServiceRequest.includes(:city).find_each do |service_request|
-    add polymorphic_url(service_request, default_url_options), lastmod: service_request.updated_at, changefreq: 'weekly'
+    add service_request_url(service_request, default_url_options), lastmod: service_request.updated_at, changefreq: 'weekly'
   end
 end


### PR DESCRIPTION
Was generating links that look like `https://status.open311.org/https://status.open311.org/cities/ottawa/requests/201800866923/recreation-and-culture-park-maintenance-garbage-cans-in-parks-full`